### PR TITLE
Fix command typo when logging pip-diff failures

### DIFF
--- a/bin/steps/pip-uninstall
+++ b/bin/steps/pip-uninstall
@@ -13,7 +13,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
 
     if ! pip-diff --stale requirements-declared.txt requirements.txt --exclude setuptools pip wheel > .heroku/python/requirements-stale.txt; then
-      mount "failure.bad-requirements"
+      mcount "failure.bad-requirements"
     fi
 
     rm -fr requirements-declared.txt


### PR DESCRIPTION
To determine stale requirements, we invoke `pip-diff` from `./vendor/pip-pop`.
When `pip-diff` encounters an unexpected failure, a count should be logged 
using `mcount` from heroku/buildpack-stdlib, and compilation continued.

Due to a typo, `mount(8)` is invoked instead of `mcount`, with an invalid
argument. Under `set +e`, this error would abort compilation.