### PR TITLE
Upgrade to pip 19

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ PY27="python-2.7"
 # Which stack is used (for binary downloading), if none is provided (e.g. outside of Heroku)?
 DEFAULT_PYTHON_STACK="cedar-14"
 # If pip doesn't match this version (the version we install), run the installer.
-PIP_UPDATE="9.0.2"
+PIP_UPDATE="19.2.2"
 
 export DEFAULT_PYTHON_STACK PIP_UPDATE
 export PY37 PY36 PY35 PY27 PY34

--- a/bin/compile
+++ b/bin/compile
@@ -61,6 +61,19 @@ DEFAULT_PYTHON_STACK="cedar-14"
 # If pip doesn't match this version (the version we install), run the installer.
 PIP_UPDATE="19.2.2"
 
+for file in "$BUILD_DIR/runtime.txt" "$CACHE_DIR/.heroku/python-version" ; do
+    [ -f "$file" ] || continue
+
+    version=$(tr -d '[:space:]' < "$file")
+
+    case "$version" in "$PY34"*)
+        # Python 3.4 support was dropped in pip >= 19.2.
+        PIP_UPDATE="19.1.1"
+        break
+        ;;
+    esac
+done
+
 export DEFAULT_PYTHON_STACK PIP_UPDATE
 export PY37 PY36 PY35 PY27 PY34
 

--- a/vendor/pip-pop/pip-diff
+++ b/vendor/pip-pop/pip-diff
@@ -12,9 +12,24 @@ Options:
 """
 import os
 from docopt import docopt
-from pip.req import parse_requirements
-from pip.index import PackageFinder
-from pip._vendor.requests import session
+
+try:  # pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession as session
+
+    def PackageFinder(find_links, index_urls, session=None):
+        from pip._internal.index import PackageFinder
+        from pip._internal.models.search_scope import SearchScope
+        from pip._internal.models.selection_prefs import SelectionPreferences
+
+        search_scope = SearchScope.create(find_links, index_urls)
+        selection_prefs = SelectionPreferences(allow_yanked=False)
+        return PackageFinder.create(search_scope, selection_prefs, session=session)
+
+except ImportError:  # pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.index import PackageFinder
+    from pip._vendor.requests import session
 
 requests = session()
 

--- a/vendor/pip-pop/pip-grep
+++ b/vendor/pip-pop/pip-grep
@@ -10,9 +10,25 @@ Options:
 import os
 import sys
 from docopt import docopt
-from pip.req import parse_requirements
-from pip.index import PackageFinder
-from pip._vendor.requests import session
+
+try:  # pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession as session
+
+    def PackageFinder(find_links, index_urls, session=None):
+        from pip._internal.index import PackageFinder
+        from pip._internal.models.search_scope import SearchScope
+        from pip._internal.models.selection_prefs import SelectionPreferences
+
+        search_scope = SearchScope.create(find_links, index_urls)
+        selection_prefs = SelectionPreferences(allow_yanked=False)
+        return PackageFinder.create(search_scope, selection_prefs, session=session)
+
+except ImportError:  # pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.index import PackageFinder
+    from pip._vendor.requests import session
+
 
 requests = session()
 


### PR DESCRIPTION
This PR upgrades [pip](https://pypi.org/project/pip/) to version 19.x. This upgrade is the first step to provide support for pyproject.toml-based projects ([PEP 517](https://www.python.org/dev/peps/pep-0517/)), such as those managed by [poetry](https://poetry.eustace.io) and [flit](https://github.com/takluyver/flit).

- Upgrade to pip 19.2.2, for projects using Python 2.7 and >= 3.5.
- Upgrade to pip 19.1.1, for Python 3.4 projects. 

Note that pip 19.2 dropped Python 3.4 support, hence the version difference.

Patch the vendorized `pip-pop` package, which is used by the `pip-uninstall`, `gdal`, and `pylibmc` steps. It relies on internal pip modules changed by the update.