### PR TITLE
Fix typo in command to log pip-diff failure

### DIFF
--- a/bin/steps/pip-uninstall
+++ b/bin/steps/pip-uninstall
@@ -13,7 +13,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
 
     if ! pip-diff --stale requirements-declared.txt requirements.txt --exclude setuptools pip wheel > .heroku/python/requirements-stale.txt; then
-      mount "failure.bad-requirements"
+      mcount "failure.bad-requirements"
     fi
 
     rm -fr requirements-declared.txt


### PR DESCRIPTION
Due to a typo, `mount(8)` is invoked instead of `mcount` from heroku/buildpack-stdlib.

The `pip-diff` tool from `vendor/pip-pop` is used to determine stale requirements. When `pip-diff` encounters an unexpected failure, a count should be logged using `mcount`.