### PR TITLE
Allow running specific tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ check:
 
 test-heroku-16:
 	@echo "Running tests in docker (heroku-16)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-16" heroku/heroku:16-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-16" heroku/heroku:16-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run $(TESTS);'
 	@echo ""
 
 test-heroku-18:
 	@echo "Running tests in docker (heroku-18)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-18" heroku/heroku:18-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-18" heroku/heroku:18-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run $(TESTS);'
 	@echo ""
 
 buildenv-heroku-16:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ make test-heroku-18
 make test-heroku-16
 ```
 
+You can also specify which tests to run:
+
+```
+make test TESTS="testPython3_7 testGitEgg"
+```
+
 The tests are run via the vendored
 [shunit2](https://github.com/kward/shunit2)
 test framework.

--- a/test/run
+++ b/test/run
@@ -315,4 +315,17 @@ assertFile() {
   assertEquals "$1" "$(cat ${compile_dir}/$2)"
 }
 
+# If tests are passed as command-line arguments, only run those tests.
+if [ $# -gt 0 ]; then
+  shunit_funcs_="$*"
+  set --
+
+  suite() {
+    for shunit_func_ in ${shunit_funcs_}; do
+      suite_addTest ${shunit_func_}
+    done
+    unset shunit_func_
+  }
+fi
+
 source $(pwd)/test/shunit2


### PR DESCRIPTION
Make it possible to specify individual tests to run, to facilitate debugging. Running the entire test suite every time can take quite long. Tests can be specified by passing the TESTS variable to `make test`.

Note that the test script uses the deprecated `suite` hook to build the test suite from the command-line arguments, if there are any. Upstream `shunit2` already [does this by default](https://github.com/kward/shunit2#cmd-line-args).